### PR TITLE
Strict signing cert url check

### DIFF
--- a/lib/heroic/sns/message.rb
+++ b/lib/heroic/sns/message.rb
@@ -125,7 +125,7 @@ module Heroic
         if signature_version != '1'
           raise Error.new("unknown signature version: #{signature_version}", self)
         end
-        if signing_cert_url !~ %r[^https://.*amazonaws\.com/]
+        if signing_cert_url !~ %r{\Ahttps://sns\.[a-z]{2}(?:-gov)?-(?:notificationorth|south|east|west|central){1,2}-\d+\.amazonaws\.com/}
           raise Error.new("signing certificate is not from amazonaws.com", self)
         end
         text = string_to_sign # will warn of invalid Type

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -6,14 +6,19 @@
 module Heroic
   module SNS
 
-    TEST_CERT_URL = 'https://sns.test.amazonaws.com/self-signed.pem'
+    TEST_CERT_URL = 'https://sns.xx-east-1.amazonaws.com/self-signed.pem'
     TEST_CERT_KEY = OpenSSL::PKey::RSA.new(File.read('test/fixtures/sns.key'))
+    FAKE_CERT_URL_S3 = 'https://sns.s3.amazonaws.com/self-signed.pem'
+    FAKE_CERT_URL_OTHER = 'https://example.com/sns.us-east-1.amazonaws.com/self-signed.pem'
 
     begin
       # Insert the certificate in the cache so that these tests aren't dependent
       # on network access (or the fact that the certificate is fake).
       cert_data = File.read('test/fixtures/sns.crt')
-      CERTIFICATE_CACHE.put(TEST_CERT_URL, OpenSSL::X509::Certificate.new(cert_data))
+      cert = OpenSSL::X509::Certificate.new(cert_data)
+      CERTIFICATE_CACHE.put(TEST_CERT_URL, cert)
+      CERTIFICATE_CACHE.put(FAKE_CERT_URL_S3, cert)
+      CERTIFICATE_CACHE.put(FAKE_CERT_URL_OTHER, cert)
     end
 
     class Message
@@ -22,8 +27,11 @@ module Heroic
         @msg['Timestamp'] = t.utc.xmlschema(3)
       end
 
+      def update_signing_cert_url!(url = nil)
+        @msg['SigningCertURL'] = url || TEST_CERT_URL
+      end
+
       def sign!
-        @msg['SigningCertURL'] = TEST_CERT_URL
         signature = TEST_CERT_KEY.sign(OpenSSL::Digest::SHA1.new, string_to_sign)
         @msg['Signature'] = Base64::encode64(signature)
       end

--- a/test/test_endpoint.rb
+++ b/test/test_endpoint.rb
@@ -10,6 +10,7 @@ class EndpointTest < Test::Unit::TestCase
     json = File.read("test/fixtures/#{name}.json")
     @msg = Heroic::SNS::Message.new(json)
     @msg.update_timestamp!
+    @msg.update_signing_cert_url!
     @msg.sign!
     @env = {
       'HTTP_X_AMZ_SNS_MESSAGE_TYPE' => @msg.type,

--- a/test/test_message.rb
+++ b/test/test_message.rb
@@ -4,11 +4,11 @@ require 'helper'
 
 class MessageTest < Test::Unit::TestCase
 
-  def sns(name, timestamp: Time.now, signing_cert_url: nil)
+  def sns(name, options = {})
     json = File.read("test/fixtures/#{name}.json")
     msg = Heroic::SNS::Message.new(json)
-    msg.update_timestamp!(timestamp)
-    msg.update_signing_cert_url!(signing_cert_url)
+    msg.update_timestamp!(options[:timestamp] || Time.now)
+    msg.update_signing_cert_url!(options[:signing_cert_url])
     msg.sign!
     return msg
   end
@@ -54,7 +54,7 @@ class MessageTest < Test::Unit::TestCase
 
   def test_untrusted_cert_url_s3
     cert_url = Heroic::SNS::FAKE_CERT_URL_S3
-    msg = sns("notification", signing_cert_url: cert_url)
+    msg = sns("notification", :signing_cert_url => cert_url)
     assert_equal cert_url, msg.signing_cert_url
     assert_raises Heroic::SNS::Error do
       msg.verify!
@@ -63,7 +63,7 @@ class MessageTest < Test::Unit::TestCase
 
   def test_untrusted_cert_url_other
     cert_url = Heroic::SNS::FAKE_CERT_URL_OTHER
-    msg = sns("subscription", signing_cert_url: cert_url)
+    msg = sns("subscription", :signing_cert_url => cert_url)
     assert_equal cert_url, msg.signing_cert_url
     assert_raises Heroic::SNS::Error do
       msg.verify!
@@ -72,7 +72,7 @@ class MessageTest < Test::Unit::TestCase
 
   def test_expired
     t = Time.utc(1984, 5)
-    msg = sns("notification", timestamp: t)
+    msg = sns("notification", :timestamp => t)
     assert_equal t, msg.timestamp
     assert_raises Heroic::SNS::Error do
       msg.verify!


### PR DESCRIPTION
Check that the URL is on amazonaws.com domain.

* Reject URLs that are for other domains but contain amazonaws.com in the path.
* Reject URLs that can contain unofficial content, e.g. on S3.

Restrictive check allows all current AWS regions (including Gov Cloud)
and any following the same pattern. See [List of SNS regional
endpoints](https://docs.aws.amazon.com/general/latest/gr/rande.html#sns_region)