### PR TITLE
Support ruby 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: ruby
 rvm:
+  - "2.7.0"
+  - "2.6.5"
+  - "2.5.7"
+  - "2.4.9"
   - "2.3.1"
   - "2.2.5"
   - "2.1.9"
@@ -13,6 +17,8 @@ before_install:
   - gem update bundler
 matrix:
   exclude:
+    - rvm: 2.7.0
+      gemfile: gemfiles/Gemfile.rack-1.x
     - rvm: 2.1.9
       gemfile: gemfiles/Gemfile.rack-2.x
     - rvm: 2.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ rvm:
   - "1.9.3"
   - "1.8.7"
 gemfile:
+  - Gemfile
   - gemfiles/Gemfile.rack-1.x
-  - gemfiles/Gemfile.rack-2.x
 before_install:
   - gem update bundler
 matrix:
@@ -20,10 +20,10 @@ matrix:
     - rvm: 2.7.0
       gemfile: gemfiles/Gemfile.rack-1.x
     - rvm: 2.1.9
-      gemfile: gemfiles/Gemfile.rack-2.x
+      gemfile: Gemfile
     - rvm: 2.0.0
-      gemfile: gemfiles/Gemfile.rack-2.x
+      gemfile: Gemfile
     - rvm: 1.9.3
-      gemfile: gemfiles/Gemfile.rack-2.x
+      gemfile: Gemfile
     - rvm: 1.8.7
-      gemfile: gemfiles/Gemfile.rack-2.x
+      gemfile: Gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,5 @@ source "http://rubygems.org"
 
 gemspec
 
-gem "rake", '~> 10.3'
+gem "rake"
+gem "rack", "~> 2.0"

--- a/gemfiles/Gemfile.rack-1.x
+++ b/gemfiles/Gemfile.rack-1.x
@@ -4,3 +4,4 @@ gemspec :path => ".."
 
 gem "rake", "~> 10.3"
 gem "rack", "~> 1.0"
+gem "json", "~> 1.7"

--- a/gemfiles/Gemfile.rack-2.x
+++ b/gemfiles/Gemfile.rack-2.x
@@ -1,5 +1,0 @@
-source "http://rubygems.org"
-
-gemspec path: ".."
-
-gem "rack", "~> 2.0"

--- a/heroic-sns.gemspec
+++ b/heroic-sns.gemspec
@@ -27,7 +27,7 @@ EOD
   s.platform = Gem::Platform::RUBY
   s.required_ruby_version = '>= 1.8.7'
   s.add_development_dependency 'rdoc', '~> 4.0'
-  s.add_development_dependency 'test-unit', '1.2.3'
+  s.add_development_dependency 'test-unit', '3.3.5'
   s.add_runtime_dependency 'rack', '>= 1.4'
   s.add_runtime_dependency 'json', '>= 1.7'
 end

--- a/lib/heroic/sns/endpoint.rb
+++ b/lib/heroic/sns/endpoint.rb
@@ -115,10 +115,10 @@ module Heroic
           message.verify!
           case message.type
           when 'SubscriptionConfirmation'
-            open(message.subscribe_url) if @auto_confirm
+            URI.parse(message.subscribe_url).open if @auto_confirm
             return OK_RESPONSE unless @auto_confirm.nil?
           when 'UnsubscribeConfirmation'
-            open(message.subscribe_url) if @auto_resubscribe
+            URI.parse(message.subscribe_url).open if @auto_resubscribe
             return OK_RESPONSE unless @auto_resubscribe.nil?
           end
           env['sns.message'] = message
@@ -139,7 +139,7 @@ module Heroic
           begin
             message = Message.new(env['rack.input'].read)
             message.verify!
-            open(message.unsubscribe_url)
+            URI.parse(message.unsubscribe_url).open
           rescue => e
             raise Error.new("error handling off-topic notification: #{e.message}", message)
           end

--- a/lib/heroic/sns/message.rb
+++ b/lib/heroic/sns/message.rb
@@ -1,6 +1,7 @@
 require 'json'
 require 'base64'
 require 'heroic/lru_cache'
+require 'open-uri'
 
 module Heroic
   module SNS
@@ -10,7 +11,7 @@ module Heroic
 
     CERTIFICATE_CACHE = Heroic::LRUCache.new(MAXIMUM_ALLOWED_CERTIFICATES) do |cert_url|
       begin
-        cert_data = open(cert_url)
+        cert_data = URI.parse(cert_url).open
         OpenSSL::X509::Certificate.new(cert_data.read)
       rescue OpenSSL::X509::CertificateError => e
         raise SNS::Error.new("unable to parse signing certificate: #{e.message}; URL: #{cert_url}")


### PR DESCRIPTION
* Update to test-unit 3.3.5
* Add ruby versions 2.4 through 2.7 to travis matrix
* Fix URI open to avoid use of `Kernel#open` which is deprecated in ruby 2.7